### PR TITLE
Restructure tracker documentation and parameters (#2127)

### DIFF
--- a/boxmot/tracker_zoo.py
+++ b/boxmot/tracker_zoo.py
@@ -40,6 +40,9 @@ def create_tracker(
 
     # Load configuration from file or use provided dictionary
     if evolve_param_dict is None:
+        if tracker_config is None: 
+            # Load default tracker config 
+            tracker_config = get_tracker_config(tracker_type)
         with open(tracker_config, "r") as f:
             yaml_config = yaml.load(f, Loader=yaml.FullLoader)
             tracker_args = {

--- a/boxmot/trackers/basetracker.py
+++ b/boxmot/trackers/basetracker.py
@@ -14,44 +14,78 @@ class BaseTracker(ABC):
         self,
         det_thresh: float = 0.3,
         max_age: int = 30,
+        max_obs: int = 50,
         min_hits: int = 3,
         iou_threshold: float = 0.3,
-        max_obs: int = 50,
-        nr_classes: int = 80,
         per_class: bool = False,
+        nr_classes: int = 80,
         asso_func: str = "iou",
         is_obb: bool = False,
+        **kwargs,
     ):
         """
-        Initialize the BaseTracker object with detection threshold, maximum age, minimum hits,
-        and Intersection Over Union (IOU) threshold for tracking objects in video frames.
+        Initialize the BaseTracker object
 
         Parameters:
         - det_thresh (float): Detection threshold for considering detections.
-        - max_age (int): Maximum age of a track before it is considered lost.
+        - max_age (int): Maximum age (in frames) of a track before it is considered lost.
+        - max_obs (int): Maximum number of historical observations (bounding boxes) stored for each track. max_obs is always greater than max_age by minimum 5. 
         - min_hits (int): Minimum number of detection hits before a track is considered confirmed.
         - iou_threshold (float): IOU threshold for determining match between detection and tracks.
+        - per_class (bool): Enables class-separated tracking
+        - nr_classes (int): Total number of object classes that the tracker will handle (for per_class=True)
+        - asso_func (str): Algorithm name used for data association between detections and tracks
+            Options:
+                - "iou" (default): Standard Intersection over Union
+                - "iou_obb": IoU for oriented bounding boxes
+                - "hmiou": Height-modified IoU that incorporates vertical overlap ratio
+                - "giou": Generalized IoU that penalizes non-overlapping boxes
+                - "ciou": Complete IoU with center point distance and aspect ratio consistency
+                - "diou": Distance IoU that considers center point distance
+                - "centroid": Distance between centroids of bounding boxes
+                - "centroid_obb": Centroid distance for oriented bounding boxes
+        - is_obb (bool): Work with Oriented Bounding Boxes (OBB) instead of standard axis-aligned bounding boxes? 
+                If False (default): If True: dets.shape[1] == 6, i.e. (x1,y1,x2,y2,conf,cls)
+                If True: dets.shape[1] == 7, i.e. (cx,cy,w,h,angle,conf,cls)
 
         Attributes:
         - frame_count (int): Counter for the frames processed.
         - active_tracks (list): List to hold active tracks, may be used differently in subclasses.
         """
+
+        LOGGER.info("BaseTracker initialization parameters:")
+        LOGGER.info(f"det_thresh: {det_thresh}")
+        LOGGER.info(f"max_age: {max_age}")
+        LOGGER.info(f"max_obs: {max_obs}")
+        LOGGER.info(f"min_hits: {min_hits}")
+        LOGGER.info(f"iou_threshold: {iou_threshold}")
+        LOGGER.info(f"per_class: {per_class}")
+        LOGGER.info(f"nr_classes: {nr_classes}")
+        LOGGER.info(f"asso_func: {asso_func}")
+        LOGGER.info(f"is_obb: {is_obb}")
+        if kwargs:
+            LOGGER.info("Additional parameters:")
+            for key, value in kwargs.items():
+                LOGGER.info(f"{key}: {value}")
+        
         self.det_thresh = det_thresh
         self.max_age = max_age
         self.max_obs = max_obs
         self.min_hits = min_hits
-        self.per_class = per_class  # Track per class or not
-        self.nr_classes = nr_classes
         self.iou_threshold = iou_threshold
-        self.last_emb_size = None
+        self.per_class = per_class  
+        self.nr_classes = nr_classes
         self.asso_func_name = asso_func + "_obb" if is_obb else asso_func
         self.is_obb = is_obb
 
+        # Attributes
         self.frame_count = 0
         self.active_tracks = []  # This might be handled differently in derived classes
+        
         self.per_class_active_tracks = None
         self._first_frame_processed = False  # Flag to track if the first frame has been processed
         self._first_dets_processed = False
+        self.last_emb_size = None # Tracks the dimensionality of embedding vectors used for re-identification during tracking. 
 
         # Initialize per-class active tracks
         if self.per_class:

--- a/boxmot/trackers/boosttrack/boosttrack.py
+++ b/boxmot/trackers/boosttrack/boosttrack.py
@@ -14,6 +14,7 @@ from boxmot.trackers.boosttrack.assoc import (
     soft_biou_batch,
 )
 from boxmot.trackers.boosttrack.kalmanfilter import KalmanFilter
+from boxmot.utils import logger as LOGGER
 
 
 def convert_bbox_to_z(bbox):
@@ -123,32 +124,45 @@ class KalmanBoxTracker:
 
 class BoostTrack(BaseTracker):
     """
-    Initializes the BoostTrack tracker with various parameters.
+    Initialize the BoostTrack tracker with various parameters.
 
-    Args:
-        reid_weights: Path to the re-identification model weights.
-        device: Device to run the model on (e.g., 'cpu', 'cuda').
-        half: Whether to use half-precision for computations.
-        max_age: Maximum allowed frames without update.
-        min_hits: Minimum hits required to output a track.
-        det_thresh: Detection confidence threshold.
-        iou_threshold: IoU threshold for association.
-        use_ecc: Whether to use ECC for camera motion compensation.
-        min_box_area: Minimum box area for detections.
-        aspect_ratio_thresh: Aspect ratio threshold for detections.
-        cmc_method: Method for camera motion compensation.
-        lambda_iou: Weight for IoU-based association.
-        lambda_mhd: Weight for Mahalanobis distance-based association.
-        lambda_shape: Weight for shape-based association.
-        use_dlo_boost: Whether to use DLO boost.
-        use_duo_boost: Whether to use DUO boost.
-        dlo_boost_coef: Coefficient for DLO boost.
-        s_sim_corr: Whether to use shape similarity correction.
-        use_rich_s: Whether to use rich shape features.
-        use_sb: Whether to use soft-BIoU.
-        use_vt: Whether to use visual tracking.
-        with_reid: Whether to use re-identification.
-        per_class: If True, enables per-class tracking, where tracks are managed separately for each class.
+    Parameters:
+    - reid_weights (Path): Path to the re-identification model weights.
+    - device (torch.device): Device to run the model on (e.g., 'cpu', 'cuda').
+    - half (bool): Whether to use half-precision (fp16) for faster inference.
+    - det_thresh (float): Detection threshold for considering detections.
+    - max_age (int): Maximum age (in frames) of a track before it is considered lost.
+    - max_obs (int): Maximum number of historical observations stored for each track. Always greater than max_age by minimum 5.
+    - min_hits (int): Minimum number of detection hits before a track is considered confirmed.
+    - iou_threshold (float): IOU threshold for determining match between detection and tracks.
+    - per_class (bool): Enables class-separated tracking.
+    - nr_classes (int): Total number of object classes that the tracker will handle (for per_class=True).
+    - asso_func (str): Algorithm name used for data association between detections and tracks.
+    - is_obb (bool): Work with Oriented Bounding Boxes (OBB) instead of standard axis-aligned bounding boxes.
+    
+    BoostTrack-specific parameters:
+    - use_ecc (bool): Whether to use ECC for camera motion compensation.
+    - min_box_area (int): Minimum box area for detections.
+    - aspect_ratio_thresh (float): Aspect ratio threshold for detections.
+    - cmc_method (str): Method for camera motion compensation.
+    - lambda_iou (float): Weight for IoU-based association.
+    - lambda_mhd (float): Weight for Mahalanobis distance-based association.
+    - lambda_shape (float): Weight for shape-based association.
+    - use_dlo_boost (bool): Whether to use DLO boost for confidence adjustment.
+    - use_duo_boost (bool): Whether to use DUO boost for confidence adjustment.
+    - dlo_boost_coef (float): Coefficient for DLO boost.
+    - s_sim_corr (bool): Whether to use shape similarity correction.
+    - use_rich_s (bool): Whether to use rich shape features.
+    - use_sb (bool): Whether to use soft-BIoU.
+    - use_vt (bool): Whether to use visual tracking.
+    - with_reid (bool): Whether to use re-identification.
+    
+    Attributes:
+    - frame_count (int): Counter for the frames processed.
+    - active_tracks (list): List to hold active tracks.
+    - trackers (List[KalmanBoxTracker]): List of active Kalman filter trackers.
+    - cmc: Camera motion compensation object.
+    - reid_model: Re-identification model instance (if with_reid=True).
     """
 
     def __init__(
@@ -156,15 +170,21 @@ class BoostTrack(BaseTracker):
         reid_weights,
         device,
         half: bool,
-        max_age: int = 60,
-        min_hits: int = 3,
+        # BaseTracker parameters 
         det_thresh: float = 0.6,
+        max_age: int = 60,
+        max_obs: int = 50, 
+        min_hits: int = 3,
         iou_threshold: float = 0.3,
+        per_class: bool = False,
+        nr_classes: int = 80,  
+        asso_func: str = "iou",  
+        is_obb: bool = False,
+        # BoostTrack-specific parameters
         use_ecc: bool = True,
         min_box_area: int = 10,
-        aspect_ratio_thresh: bool = 1.6,
+        aspect_ratio_thresh: float = 1.6,
         cmc_method: str = "ecc",
-        # BoostTrack parameters
         lambda_iou: float = 0.5,
         lambda_mhd: float = 0.25,
         lambda_shape: float = 0.25,
@@ -172,14 +192,26 @@ class BoostTrack(BaseTracker):
         use_duo_boost: bool = True,
         dlo_boost_coef: float = 0.65,
         s_sim_corr: bool = False,
-        # BoostTrack++ parameters
         use_rich_s: bool = False,
         use_sb: bool = False,
         use_vt: bool = False,
         with_reid: bool = False,
-        per_class: bool = False,  # Enable per-class tracking if True
+        **kwargs  # Additional BaseTracker parameters
     ):
-        super().__init__(per_class=per_class)
+        
+        # Forward per_class and any additional parameters to BaseTracker
+        super().__init__(
+            det_thresh=det_thresh,
+            max_age=max_age,
+            max_obs=max_obs,
+            min_hits=min_hits,
+            iou_threshold=iou_threshold,
+            per_class=per_class,
+            nr_classes=nr_classes,
+            asso_func=asso_func,
+            is_obb=is_obb,
+            **kwargs
+        )
         self.active_tracks = []
         self.frame_count = 0
         self.trackers: List[KalmanBoxTracker] = []
@@ -217,6 +249,8 @@ class BoostTrack(BaseTracker):
             self.cmc = get_cmc_method(cmc_method)()
         else:
             self.cmc = None
+            
+        LOGGER.success("Initialized BoostTrack")
 
     @BaseTracker.setup_decorator
     @BaseTracker.per_class_decorator

--- a/boxmot/trackers/botsort/botsort.py
+++ b/boxmot/trackers/botsort/botsort.py
@@ -22,28 +22,48 @@ from boxmot.utils.matching import (
     iou_distance,
     linear_assignment,
 )
+from boxmot.utils import logger as LOGGER
 
 
 class BotSort(BaseTracker):
     """
-    BoTSORT Tracker: A tracking algorithm that combines appearance and motion-based tracking.
+    Initialize the BotSort tracker with various parameters.
 
-    Args:
-        reid_weights (str): Path to the model weights for ReID.
-        device (torch.device): Device to run the model on (e.g., 'cpu' or 'cuda').
-        half (bool): Use half-precision (fp16) for faster inference.
-        per_class (bool, optional): Whether to perform per-class tracking.
-        track_high_thresh (float, optional): Detection confidence threshold for first association.
-        track_low_thresh (float, optional): Detection confidence threshold for ignoring detections.
-        new_track_thresh (float, optional): Threshold for creating a new track.
-        track_buffer (int, optional): Frames to keep a track alive after last detection.
-        match_thresh (float, optional): Matching threshold for data association.
-        proximity_thresh (float, optional): IoU threshold for first-round association.
-        appearance_thresh (float, optional): Appearance embedding distance threshold for ReID.
-        cmc_method (str, optional): Method for correcting camera motion, e.g., "sof" (simple optical flow).
-        frame_rate (int, optional): Video frame rate, used to scale the track buffer.
-        fuse_first_associate (bool, optional): Fuse appearance and motion in the first association step.
-        with_reid (bool, optional): Use ReID features for association.
+    Parameters:
+    - reid_weights (Path): Path to the re-identification model weights.
+    - device (torch.device): Device to run the model on (e.g., 'cpu', 'cuda').
+    - half (bool): Whether to use half-precision (fp16) for faster inference.
+    - det_thresh (float): Detection threshold for considering detections.
+    - max_age (int): Maximum age (in frames) of a track before it is considered lost.
+    - max_obs (int): Maximum number of historical observations stored for each track. Always greater than max_age by minimum 5.
+    - min_hits (int): Minimum number of detection hits before a track is considered confirmed.
+    - iou_threshold (float): IOU threshold for determining match between detection and tracks.
+    - per_class (bool): Enables class-separated tracking.
+    - nr_classes (int): Total number of object classes that the tracker will handle (for per_class=True).
+    - asso_func (str): Algorithm name used for data association between detections and tracks.
+    - is_obb (bool): Work with Oriented Bounding Boxes (OBB) instead of standard axis-aligned bounding boxes.
+    
+    BotSort-specific parameters:
+    - track_high_thresh (float): Detection confidence threshold for first association.
+    - track_low_thresh (float): Detection confidence threshold for ignoring detections.
+    - new_track_thresh (float): Threshold for creating a new track.
+    - track_buffer (int): Frames to keep a track alive after last detection.
+    - match_thresh (float): Matching threshold for data association.
+    - proximity_thresh (float): IoU threshold for first-round association.
+    - appearance_thresh (float): Appearance embedding distance threshold for ReID.
+    - cmc_method (str): Method for correcting camera motion, e.g., "sof" (simple optical flow).
+    - frame_rate (int): Video frame rate, used to scale the track buffer.
+    - fuse_first_associate (bool): Fuse appearance and motion in the first association step.
+    - with_reid (bool): Use ReID features for association.
+    
+    Attributes:
+    - frame_count (int): Counter for the frames processed.
+    - active_tracks (list): List to hold active tracks.
+    - lost_stracks (list[STrack]): List of lost tracks.
+    - removed_stracks (list[STrack]): List of removed tracks.
+    - buffer_size (int): Size of the track buffer based on frame rate.
+    - max_time_lost (int): Maximum time a track can be lost.
+    - kalman_filter (KalmanFilterXYWH): Kalman filter for motion prediction.
     """
 
     def __init__(
@@ -51,7 +71,17 @@ class BotSort(BaseTracker):
         reid_weights: Path,
         device: torch.device,
         half: bool,
+        # BaseTracker parameters
+        det_thresh: float = 0.3,
+        max_age: int = 30,
+        max_obs: int = 50,
+        min_hits: int = 3,
+        iou_threshold: float = 0.3,
         per_class: bool = False,
+        nr_classes: int = 80,
+        asso_func: str = "iou",
+        is_obb: bool = False,
+        # BotSort-specific parameters
         track_high_thresh: float = 0.5,
         track_low_thresh: float = 0.1,
         new_track_thresh: float = 0.6,
@@ -60,11 +90,25 @@ class BotSort(BaseTracker):
         proximity_thresh: float = 0.5,
         appearance_thresh: float = 0.25,
         cmc_method: str = "ecc",
-        frame_rate=30,
+        frame_rate: int = 30,
         fuse_first_associate: bool = False,
         with_reid: bool = True,
+        **kwargs  # Additional BaseTracker parameters
     ):
-        super().__init__(per_class=per_class)
+        # Forward all BaseTracker parameters explicitly
+        super().__init__(
+            det_thresh=det_thresh,
+            max_age=max_age,
+            max_obs=max_obs,
+            min_hits=min_hits,
+            iou_threshold=iou_threshold,
+            per_class=per_class,
+            nr_classes=nr_classes,
+            asso_func=asso_func,
+            is_obb=is_obb,
+            **kwargs
+        )
+        
         self.lost_stracks = []  # type: list[STrack]
         self.removed_stracks = []  # type: list[STrack]
         BaseTrack.clear_count()
@@ -91,6 +135,8 @@ class BotSort(BaseTracker):
         self.cmc = get_cmc_method(cmc_method)()
         self.fuse_first_associate = fuse_first_associate
 
+        LOGGER.success("Initialized BotSort")
+        
     @BaseTracker.setup_decorator
     @BaseTracker.per_class_decorator
     def update(

--- a/boxmot/trackers/bytetrack/bytetrack.py
+++ b/boxmot/trackers/bytetrack/bytetrack.py
@@ -10,6 +10,7 @@ from boxmot.trackers.bytetrack.basetrack import BaseTrack, TrackState
 from boxmot.utils.matching import fuse_score, iou_distance, linear_assignment
 from boxmot.utils.ops import tlwh2xyah, xywh2tlwh, xywh2xyxy, xyxy2xywh
 
+from boxmot.utils import logger as LOGGER
 
 class STrack(BaseTrack):
     shared_kalman = KalmanFilterXYAH()
@@ -118,42 +119,90 @@ class STrack(BaseTrack):
 
 class ByteTrack(BaseTracker):
     """
-    BYTETracker: A tracking algorithm based on ByteTrack, which utilizes motion-based tracking.
+    Initialize the ByteTrack tracker with various parameters.
 
-    Args:
-        min_conf (float, optional): Threshold for detection confidence. Detections below this threshold are discarded.
-        track_thresh (float, optional): Threshold for detection confidence. Detections above this threshold are considered for tracking in the first association round.
-        match_thresh (float, optional): Threshold for the matching step in data association. Controls the maximum distance allowed between tracklets and detections for a match.
-        track_buffer (int, optional): Number of frames to keep a track alive after it was last detected. A longer buffer allows for more robust tracking but may increase identity switches.
-        frame_rate (int, optional): Frame rate of the video being processed. Used to scale the track buffer size.
-        per_class (bool, optional): Whether to perform per-class tracking. If True, tracks are maintained separately for each object class.
+    Parameters:
+    - det_thresh (float): Detection threshold for considering detections.
+    - max_age (int): Maximum age (in frames) of a track before it is considered lost.
+    - max_obs (int): Maximum number of historical observations stored for each track. Always greater than max_age by minimum 5.
+    - min_hits (int): Minimum number of detection hits before a track is considered confirmed.
+    - iou_threshold (float): IOU threshold for determining match between detection and tracks.
+    - per_class (bool): Enables class-separated tracking.
+    - nr_classes (int): Total number of object classes that the tracker will handle (for per_class=True).
+    - asso_func (str): Algorithm name used for data association between detections and tracks.
+    - is_obb (bool): Work with Oriented Bounding Boxes (OBB) instead of standard axis-aligned bounding boxes.
+    
+    ByteTrack-specific parameters:
+    - min_conf (float): Threshold for detection confidence. Detections below this threshold are discarded.
+    - track_thresh (float): Threshold for detection confidence. Detections above this threshold are considered for tracking in the first association round.
+    - match_thresh (float): Threshold for the matching step in data association. Controls the maximum distance allowed between tracklets and detections for a match.
+    - track_buffer (int): Number of frames to keep a track alive after it was last detected.
+    - frame_rate (int): Frame rate of the video being processed. Used to scale the track buffer size.
+    
+    Attributes:
+    - frame_count (int): Counter for the frames processed.
+    - active_tracks (list): List to hold active tracks.
+    - lost_stracks (list[STrack]): List of lost tracks.
+    - removed_stracks (list[STrack]): List of removed tracks.
+    - buffer_size (int): Size of the track buffer based on frame rate.
+    - max_time_lost (int): Maximum time a track can be lost.
+    - kalman_filter (KalmanFilterXYAH): Kalman filter for motion prediction.
     """
 
     def __init__(
         self,
+        # BaseTracker parameters
+        det_thresh: float = 0.3,
+        max_age: int = 30,
+        max_obs: int = 50,
+        min_hits: int = 3,
+        iou_threshold: float = 0.3,
+        per_class: bool = False,
+        nr_classes: int = 80,
+        asso_func: str = "iou",
+        is_obb: bool = False,
+        # ByteTrack-specific parameters
         min_conf: float = 0.1,
         track_thresh: float = 0.45,
         match_thresh: float = 0.8,
         track_buffer: int = 25,
         frame_rate: int = 30,
-        per_class: bool = False,
+        **kwargs  # Additional BaseTracker parameters
     ):
-        super().__init__(per_class=per_class)
+        # Forward all BaseTracker parameters explicitly
+        super().__init__(
+            det_thresh=det_thresh,
+            max_age=max_age,
+            max_obs=max_obs,
+            min_hits=min_hits,
+            iou_threshold=iou_threshold,
+            per_class=per_class,
+            nr_classes=nr_classes,
+            asso_func=asso_func,
+            is_obb=is_obb,
+            **kwargs
+        )
+        
+        # Track lifecycle parameters
+        self.frame_id = 0
+        self.track_buffer = track_buffer
+        self.buffer_size = int(frame_rate / 30.0 * track_buffer)
+        self.max_time_lost = self.buffer_size
+
+        # Detection thresholds
+        self.min_conf = min_conf
+        self.track_thresh = track_thresh
+        self.match_thresh = match_thresh
+        self.det_thresh = track_thresh  # Same as track_thresh
+
+        # Motion model
+        self.kalman_filter = KalmanFilterXYAH()
+        
         self.active_tracks = []  # type: list[STrack]
         self.lost_stracks = []  # type: list[STrack]
         self.removed_stracks = []  # type: list[STrack]
 
-        self.frame_id = 0
-        self.track_buffer = track_buffer
-
-        self.per_class = per_class
-        self.min_conf = min_conf
-        self.track_thresh = track_thresh
-        self.match_thresh = match_thresh
-        self.det_thresh = track_thresh
-        self.buffer_size = int(frame_rate / 30.0 * track_buffer)
-        self.max_time_lost = self.buffer_size
-        self.kalman_filter = KalmanFilterXYAH()
+        LOGGER.success("Initialized ByteTrack")
 
     @BaseTracker.setup_decorator
     @BaseTracker.per_class_decorator

--- a/boxmot/trackers/hybridsort/hybridsort.py
+++ b/boxmot/trackers/hybridsort/hybridsort.py
@@ -18,6 +18,7 @@ from boxmot.trackers.hybridsort.association import (
     embedding_distance,
     linear_assignment,
 )
+from boxmot.utils import logger as LOGGER
 
 np.random.seed(0)
 
@@ -349,48 +350,75 @@ class KalmanBoxTracker(object):
 
 class HybridSort(BaseTracker):
     """
-    HybridSORT Tracker: A tracking algorithm that utilizes a combination of appearance and motion-based tracking
-    and temporal consistency models (TCM) for improved tracking accuracy and robustness.
+    Initialize the HybridSort tracker with various parameters.
 
-    Args:
-        reid_weights (str): Path to the model weights for ReID (Re-Identification).
-        device (str): Device on which to run the model (e.g., 'cpu' or 'cuda').
-        half (bool): Whether to use half-precision (fp16) for faster inference on compatible devices.
-        det_thresh (float): Detection confidence threshold. Detections below this threshold will be ignored in the first association step.
-        per_class (bool, optional): Whether to perform per-class tracking. If True, tracks are maintained separately for each object class.
-        max_age (int, optional): Maximum number of frames to keep a track alive without any detections.
-        min_hits (int, optional): Minimum number of hits required to confirm a track.
-        iou_threshold (float, optional): Intersection over Union (IoU) threshold for data association.
-        delta_t (int, optional): Time delta for velocity estimation in Kalman Filter.
-        asso_func (str, optional): Association function to use for data association. Options include "iou" for IoU-based association.
-        inertia (float, optional): Weight for inertia in motion modeling. Higher values make tracks less responsive to changes.
-        longterm_reid_weight (float, optional): Weight for the long-term ReID feature in the association process.
-        TCM_first_step_weight (float, optional): Weight for the Temporal Consistency Model (TCM) in the first association step.
-        use_byte (bool, optional): Whether to use BYTE association in the second association step.
+    Parameters:
+    - reid_weights (Path): Path to the re-identification model weights.
+    - device (torch.device): Device to run the model on (e.g., 'cpu', 'cuda').
+    - half (bool): Whether to use half-precision (fp16) for faster inference.
+    - det_thresh (float): Detection threshold for considering detections.
+    - max_age (int): Maximum age (in frames) of a track before it is considered lost.
+    - max_obs (int): Maximum number of historical observations stored for each track. Always greater than max_age by minimum 5.
+    - min_hits (int): Minimum number of detection hits before a track is considered confirmed.
+    - iou_threshold (float): IOU threshold for determining match between detection and tracks.
+    - per_class (bool): Enables class-separated tracking.
+    - nr_classes (int): Total number of object classes that the tracker will handle (for per_class=True).
+    - asso_func (str): Algorithm name used for data association between detections and tracks.
+    - is_obb (bool): Work with Oriented Bounding Boxes (OBB) instead of standard axis-aligned bounding boxes.
+    
+    HybridSort-specific parameters:
+    - delta_t (int): Time window size for motion estimation in frames.
+    - inertia (float): Motion model weight for data association.
+    - longterm_reid_weight (float): Weight for long-term ReID features in association.
+    - TCM_first_step_weight (float): Weight for Temporal Consistency Model in first association step.
+    - use_byte (bool): Whether to use BYTE association in second association step.
+    - ECC (bool): Whether to use Enhanced Correlation Coefficient for camera motion compensation.
+    
+    Attributes:
+    - frame_count (int): Counter for the frames processed.
+    - active_tracks (list): List to hold active tracks.
+    - model: ReID model for appearance feature extraction.
+    - cmc: Camera motion compensation object.
     """
 
     def __init__(
         self,
         reid_weights,
         device,
-        half,
-        det_thresh,
-        per_class=False,
-        max_age=30,
-        min_hits=3,
-        iou_threshold=0.3,
-        delta_t=3,
-        asso_func="iou",
-        inertia=0.2,
-        longterm_reid_weight=0,
-        TCM_first_step_weight=0,
-        use_byte=False,
+        half: bool,
+        # BaseTracker parameters
+        det_thresh: float = 0.3,
+        max_age: int = 30,
+        max_obs: int = 50,
+        min_hits: int = 3,
+        iou_threshold: float = 0.3,
+        per_class: bool = False,
+        nr_classes: int = 80,
+        asso_func: str = "iou",
+        is_obb: bool = False,
+        # HybridSort-specific parameters
+        delta_t: int = 3,
+        inertia: float = 0.2,
+        longterm_reid_weight: float = 0,
+        TCM_first_step_weight: float = 0,
+        use_byte: bool = False,
+        **kwargs  # Additional BaseTracker parameters
     ):
-        super().__init__(max_age=max_age, per_class=per_class, asso_func=asso_func)
+        # Forward all BaseTracker parameters explicitly
+        super().__init__(
+            det_thresh=det_thresh,
+            max_age=max_age,
+            max_obs=max_obs,
+            min_hits=min_hits,
+            iou_threshold=iou_threshold,
+            per_class=per_class,
+            nr_classes=nr_classes,
+            asso_func=asso_func,
+            is_obb=is_obb,
+            **kwargs
+        )
 
-        """
-        Sets key parameters for SORT
-        """
+        # Store parameters for HybridSort
         self.max_age: int = max_age
         self.min_hits: int = min_hits
         self.iou_threshold: float = iou_threshold
@@ -422,6 +450,9 @@ class HybridSort(BaseTracker):
         ).model
         self.cmc = get_cmc_method("ecc")()
 
+        LOGGER.success("Initialized HybridSort")
+        
+        
     def camera_update(self, trackers, warp_matrix):
         for tracker in trackers:
             tracker.camera_update(warp_matrix)


### PR DESCRIPTION
* Update BaseTracker

Consistent ordering of parameters in function call and docstring.

* Update boosttrack

Separate between BaseTracker and BoostTracker specific arguments. Sort arguments for BaseTracker first and in the same order as in BaseTracker. Forward BaseTracker specific arguments into initialization call of BaseTracker. Bugfix in aspect_ratio_thresh which had wrong typehint (bool instead of float).

* Update botsort

Separate between BaseTracker and BotSort specific arguments. Sort arguments for BaseTracker first and in the same order as in BaseTracker. Forward BaseTracker specific arguments into initialization call of BaseTracker. Added type hint for frame_rate.

* Update ByteTrack

Separate between BaseTracker and ByteTrack specific arguments. Sort arguments for BaseTracker first and in the same order as in BaseTracker. Forward BaseTracker specific arguments into initialization call of BaseTracker.

* Update DeepOCSort

Separate between BaseTracker and DeepOCSort specific arguments. Sort arguments for BaseTracker first and in the same order as in BaseTracker. Forward BaseTracker specific arguments into initialization call of BaseTracker.

* Update HybridSort

Separate between BaseTracker and HybridSort specific arguments. Sort arguments for BaseTracker first and in the same order as in BaseTracker. Forward BaseTracker specific arguments into initialization call of BaseTracker.

* Update OCSort

Separate between BaseTracker and OCSort specific arguments. Sort arguments for BaseTracker first and in the same order as in BaseTracker. Forward BaseTracker specific arguments into initialization call of BaseTracker. Naming consistency: sso_threshold: float = iou_threshold

* Update StrongSort

StrongSort now inherits from BaseTracker object. Separate between BaseTracker and StrongSort specific arguments. Sort arguments for BaseTracker first and in the same order as in BaseTracker. Forward BaseTracker specific arguments into initialization call of BaseTracker.

* if tracker_config is not given, load default

Using get_tracker_config()

* Print BaseTracker initialization parameters

Optional handle verbose (bool)

* Instead of verbose flag use LOGGER module

* Print initialization statement through LOGGER

whenever initialization of a tracker has been completed